### PR TITLE
fix: avoid linear weakref subscription lookup

### DIFF
--- a/src/subscriptions/stencil.test.ts
+++ b/src/subscriptions/stencil.test.ts
@@ -109,6 +109,72 @@ describe('stencilSubscription', () => {
     expect(forceUpdate).toHaveBeenCalledTimes(1);
   });
 
+  it('deduplicates an element independently in each property bucket', async () => {
+    vi.useFakeTimers();
+
+    const elm = { isConnected: true, id: 'shared' };
+    const forceUpdate = vi.fn(() => true);
+    const getRenderingRef = vi.fn().mockReturnValue(elm);
+
+    coreMock.exports.forceUpdate = forceUpdate as any;
+    coreMock.exports.getRenderingRef = getRenderingRef as any;
+
+    const { stencilSubscription } = await import('./stencil');
+    const subscription = stencilSubscription<{ first: number; second: number }>();
+
+    subscription.get?.('first');
+    subscription.get?.('second');
+    subscription.get?.('first');
+
+    subscription.set?.('first', 1, 0);
+
+    expect(forceUpdate).toHaveBeenCalledTimes(1);
+    expect(forceUpdate).toHaveBeenCalledWith(elm);
+
+    forceUpdate.mockClear();
+    subscription.set?.('second', 1, 0);
+
+    expect(forceUpdate).toHaveBeenCalledTimes(1);
+    expect(forceUpdate).toHaveBeenCalledWith(elm);
+
+    vi.runAllTimers();
+  });
+
+  it('allows a connected element to resubscribe after cleanup', async () => {
+    vi.useFakeTimers();
+
+    const elm = { isConnected: false, id: 'reconnected' };
+    const forceUpdate = vi.fn(() => true);
+    const getRenderingRef = vi.fn().mockReturnValue(elm);
+
+    coreMock.exports.forceUpdate = forceUpdate as any;
+    coreMock.exports.getRenderingRef = getRenderingRef as any;
+
+    const { stencilSubscription } = await import('./stencil');
+    const subscription = stencilSubscription<{ prop: number }>();
+
+    subscription.get?.('prop');
+    subscription.set?.('prop', 1, 0);
+
+    expect(forceUpdate).toHaveBeenCalledTimes(1);
+    expect(forceUpdate).toHaveBeenCalledWith(elm);
+
+    forceUpdate.mockClear();
+    vi.runAllTimers();
+
+    subscription.reset?.();
+    expect(forceUpdate).not.toHaveBeenCalled();
+
+    elm.isConnected = true;
+    subscription.get?.('prop');
+    subscription.set?.('prop', 2, 1);
+
+    expect(forceUpdate).toHaveBeenCalledTimes(1);
+    expect(forceUpdate).toHaveBeenCalledWith(elm);
+
+    vi.runAllTimers();
+  });
+
   it('handles garbage collected elements', async () => {
     const originalWeakRef = global.WeakRef;
     const gcedElm = { id: 'gced' };

--- a/src/subscriptions/stencil.ts
+++ b/src/subscriptions/stencil.ts
@@ -15,12 +15,11 @@ const isConnected = (maybeElement: any) => !('isConnected' in maybeElement) || m
 
 const cleanupElements = debounce((map: Map<string, Set<WeakRef<any>>>) => {
   map.forEach((refs, key) => {
-    const nextRefs = new Set(
-      [...refs].filter((ref) => {
-        const elm = ref.deref();
-        return elm && isConnected(elm);
-      }),
-    );
+    const nextRefs = new Set<WeakRef<any>>();
+    refs.forEach((ref) => {
+      const elm = ref.deref();
+      if (elm && isConnected(elm)) nextRefs.add(ref);
+    });
     map.set(key, nextRefs);
   });
 }, 2_000);
@@ -56,13 +55,11 @@ export const stencilSubscription = <T>(): Subscription<T> => {
     set: (propName) => {
       const refs = elmsToUpdate.get(propName as string);
       if (refs) {
-        const nextRefs = new Set(
-          [...refs].filter((ref) => {
-            const elm = ref.deref();
-            if (!elm) return false;
-            return ensureForceUpdate(elm);
-          }),
-        );
+        const nextRefs = new Set<WeakRef<any>>();
+        refs.forEach((ref) => {
+          const elm = ref.deref();
+          if (elm && ensureForceUpdate(elm)) nextRefs.add(ref);
+        });
         elmsToUpdate.set(propName as string, nextRefs);
       }
       cleanupElements(elmsToUpdate);

--- a/src/subscriptions/stencil.ts
+++ b/src/subscriptions/stencil.ts
@@ -13,14 +13,16 @@ import { appendToMap, debounce } from '../utils';
  */
 const isConnected = (maybeElement: any) => !('isConnected' in maybeElement) || maybeElement.isConnected;
 
-const cleanupElements = debounce((map: Map<string, WeakRef<any>[]>) => {
-  for (let key of map.keys()) {
-    const refs = map.get(key).filter((ref) => {
-      const elm = ref.deref();
-      return elm && isConnected(elm);
-    });
-    map.set(key, refs);
-  }
+const cleanupElements = debounce((map: Map<string, Set<WeakRef<any>>>) => {
+  map.forEach((refs, key) => {
+    const nextRefs = new Set(
+      [...refs].filter((ref) => {
+        const elm = ref.deref();
+        return elm && isConnected(elm);
+      }),
+    );
+    map.set(key, nextRefs);
+  });
 }, 2_000);
 
 const core = StencilCore as unknown as {
@@ -40,24 +42,27 @@ export const stencilSubscription = <T>(): Subscription<T> => {
 
   const ensureForceUpdate = forceUpdate;
   const ensureGetRenderingRef = getRenderingRef;
-  const elmsToUpdate = new Map<string, WeakRef<any>[]>();
+  const refsByElement = new WeakMap<any, WeakRef<any>>();
+  const elmsToUpdate = new Map<string, Set<WeakRef<any>>>();
 
   return {
     dispose: () => elmsToUpdate.clear(),
     get: (propName) => {
       const elm = ensureGetRenderingRef();
       if (elm) {
-        appendToMap(elmsToUpdate, propName as string, elm);
+        appendToMap(elmsToUpdate, refsByElement, propName as string, elm);
       }
     },
     set: (propName) => {
       const refs = elmsToUpdate.get(propName as string);
       if (refs) {
-        const nextRefs = refs.filter((ref) => {
-          const elm = ref.deref();
-          if (!elm) return false;
-          return ensureForceUpdate(elm);
-        });
+        const nextRefs = new Set(
+          [...refs].filter((ref) => {
+            const elm = ref.deref();
+            if (!elm) return false;
+            return ensureForceUpdate(elm);
+          }),
+        );
         elmsToUpdate.set(propName as string, nextRefs);
       }
       cleanupElements(elmsToUpdate);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,46 +2,82 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { appendToMap, debounce } from './utils';
 
 describe('appendToMap', () => {
-  let testMap: Map<string, WeakRef<Object>[]>;
+  let testMap: Map<string, Set<WeakRef<Object>>>;
+  let refsByValue: WeakMap<Object, WeakRef<Object>>;
 
   beforeEach(() => {
     testMap = new Map();
+    refsByValue = new WeakMap();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should add value to empty map', () => {
     const obj = { id: 1 };
-    appendToMap(testMap, 'key1', obj);
+    appendToMap(testMap, refsByValue, 'key1', obj);
 
-    const refs = testMap.get('key1');
+    const refs = [...testMap.get('key1')!];
     expect(refs).toHaveLength(1);
-    expect(refs![0].deref()).toBe(obj);
+    expect(refs[0].deref()).toBe(obj);
   });
 
-  it('should append value to existing array', () => {
+  it('should append value to existing set', () => {
     const obj1 = { id: 1 };
     const obj2 = { id: 3 };
 
-    appendToMap(testMap, 'key1', obj1);
-    appendToMap(testMap, 'key1', obj2);
+    appendToMap(testMap, refsByValue, 'key1', obj1);
+    appendToMap(testMap, refsByValue, 'key1', obj2);
 
-    const refs = testMap.get('key1');
+    const refs = [...testMap.get('key1')!];
     expect(refs).toHaveLength(2);
-    expect(refs![0].deref()).toBe(obj1);
-    expect(refs![1].deref()).toBe(obj2);
+    expect(refs[0].deref()).toBe(obj1);
+    expect(refs[1].deref()).toBe(obj2);
   });
 
   it('should not append duplicate value', () => {
     const obj1 = { id: 1 };
     const obj2 = { id: 2 };
 
-    appendToMap(testMap, 'key1', obj1);
-    appendToMap(testMap, 'key1', obj2);
-    appendToMap(testMap, 'key1', obj1); // Duplicate
+    appendToMap(testMap, refsByValue, 'key1', obj1);
+    appendToMap(testMap, refsByValue, 'key1', obj2);
+    appendToMap(testMap, refsByValue, 'key1', obj1); // Duplicate
 
-    const refs = testMap.get('key1');
+    const refs = [...testMap.get('key1')!];
     expect(refs).toHaveLength(2);
-    expect(refs![0].deref()).toBe(obj1);
-    expect(refs![1].deref()).toBe(obj2);
+    expect(refs[0].deref()).toBe(obj1);
+    expect(refs[1].deref()).toBe(obj2);
+  });
+
+  it('reuses the same WeakRef across property buckets', () => {
+    const obj = { id: 1 };
+    appendToMap(testMap, refsByValue, 'key1', obj);
+    appendToMap(testMap, refsByValue, 'key2', obj);
+    const key1Ref = [...testMap.get('key1')!][0];
+    const key2Ref = [...testMap.get('key2')!][0];
+    expect(key1Ref).toBe(key2Ref);
+    expect(key1Ref.deref()).toBe(obj);
+  });
+
+  it('does not dereference existing refs when deduplicating the same value', () => {
+    const deref = vi.fn();
+    class TestWeakRef<T extends object> {
+      constructor(private readonly value: T) {}
+
+      deref(): T {
+        deref();
+        return this.value;
+      }
+    }
+    vi.stubGlobal('WeakRef', TestWeakRef);
+
+    const obj = { id: 1 };
+    appendToMap(testMap, refsByValue, 'key1', obj);
+    appendToMap(testMap, refsByValue, 'key1', obj);
+
+    expect([...testMap.get('key1')!]).toHaveLength(1);
+    expect(deref).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,20 @@
-export const appendToMap = <K, V extends Object>(map: Map<K, WeakRef<V>[]>, propName: K, value: V) => {
+export const appendToMap = <K, V extends Object>(
+  map: Map<K, Set<WeakRef<V>>>,
+  refsByValue: WeakMap<V, WeakRef<V>>,
+  propName: K,
+  value: V,
+): void => {
+  let ref = refsByValue.get(value);
+  if (!ref) {
+    ref = new WeakRef(value);
+    refsByValue.set(value, ref);
+  }
   let refs = map.get(propName);
   if (!refs) {
-    refs = [];
+    refs = new Set();
     map.set(propName, refs);
   }
-  if (!refs.some((ref) => ref.deref() === value)) {
-    refs.push(new WeakRef(value));
-  }
+  refs.add(ref);
 };
 
 export const debounce = <T extends (...args: any[]) => any>(fn: T, ms: number): ((...args: Parameters<T>) => void) => {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (no documentation changes needed)
- [x] Build (`npm run build`) was run locally and passed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Stencil Store tracks each property's Stencil subscribers in an array of `WeakRef`s and deduplicates subscriptions by scanning the array:

```ts
refs.some((ref) => ref.deref() === value)
```

Store reads occur while components render. For a property with N subscribers, a repeated read can perform up to N `deref()` calls. Registering N distinct elements therefore has cumulative O(N²) lookup work.

GitHub Issue Number: N/A

## What is the new behavior?

- Each Stencil subscription maintains one canonical `WeakRef` per element in a `WeakMap<Element, WeakRef<Element>>`.
- Per-property subscribers are stored in `Set<WeakRef<Element>>`, providing average-O(1) identity deduplication without calling `deref()` during registration.
- The existing update and two-second cleanup paths continue to dereference subscribers when iteration is necessary, removing collected, disconnected, and rejected subscribers.
- Subscriber iteration order—and therefore `forceUpdate` invocation order—is preserved, along with the existing `get`, `set`, `reset`, and `dispose` behavior.

The store still has no strong reference path to component elements:

```text
store -> Map -> Set -> WeakRef --weak--> Element
store -> WeakMap --weak key--> Element
                 -> WeakRef --weak--> Element
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `npm run test.prettier`
- `npm run test.unit` — 64 tests passed
- `npm test`
- `npm run build`
- Added deterministic coverage proving duplicate registration performs no `deref()` calls.
- Added coverage proving one canonical `WeakRef` is reused across property buckets.
- Preserved duplicate-subscription and simulated garbage-collection coverage.
- Added coverage proving disconnected elements can be cleaned up and later resubscribe.
- Manually verified the built local package in the Stencil test app: same-property subscribers update once each, unrelated properties remain unchanged, multi-property reads work, disconnected elements can resubscribe after cleanup, and updates with no remaining subscribers produce no page errors.

## Other information

| Operation | Before | After |
|---|---:|---:|
| Repeated registration for one property | O(N), up to N `deref()` calls | average O(1), no `deref()` |
| Registering N distinct elements | cumulative O(N²) | average cumulative O(N) |
| Updating N subscribers | O(N) | O(N) |
| Preventing element garbage collection | no | no |
| Iterating subscribers | yes | yes |

### Local registration microbenchmark

Environment: Apple M3 Pro (arm64), Darwin 25.0.0, Node.js 24.15.0.

Each table cell is the median of 200 measured samples from two independent sequential runs. Each run used 20 warm-up iterations and 100 measured iterations, with 20 independent batches per sample. Before/after execution order alternated on every iteration, timing used `process.hrtime.bigint()`, and element targets remained strongly reachable for the duration of each sample. The maximum median difference between the two runs was 4.1%.

**Register N distinct elements to one property from an empty bucket**

| Elements | Before median | After median | Speedup |
|---:|---:|---:|---:|
| 100 | 0.065955 ms | 0.012629 ms | 5.22× |
| 200 | 0.247791 ms | 0.024449 ms | 10.14× |
| 500 | 1.489025 ms | 0.059801 ms | 24.90× |
| 1,000 | 6.248860 ms | 0.118962 ms | 52.53× |

**Repeat one registration N times in a prefilled N-subscriber bucket**

The prefill is excluded from the timed region.

| Existing subscribers / repeated reads | Before median | After median | Speedup |
|---:|---:|---:|---:|
| 100 | 0.120100 ms | 0.001464 ms | 82.01× |
| 200 | 0.478885 ms | 0.002907 ms | 164.71× |
| 500 | 3.042726 ms | 0.007166 ms | 424.63× |
| 1,000 | 13.516311 ms | 0.014549 ms | 929.02× |

These are local informational microbenchmark results, not CI assertions. The deterministic unit test proving duplicate registration performs zero `deref()` calls is the performance regression guard.

This PR intentionally does not change CI configuration or test-app dependencies.
