### PR TITLE
fix: restore TypeScript declaration output

### DIFF
--- a/src/observable-map.ts
+++ b/src/observable-map.ts
@@ -6,7 +6,7 @@ const unwrap = <T>(val: Invocable<T>): T => (typeof val === 'function' ? (val as
 
 export const createObservableMap = <T extends { [key: string]: any }>(
   defaultState?: Invocable<T>,
-  shouldUpdate: (newV: any, oldValue, prop: keyof T) => boolean = (a, b) => a !== b,
+  shouldUpdate: (newV: any, oldValue: any, prop: keyof T) => boolean = (a, b) => a !== b,
 ): ObservableMap<T> => {
   const resolveDefaultState = (): T => (unwrap(defaultState) ?? {}) as T;
   const initialState = resolveDefaultState();
@@ -88,14 +88,14 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   ) as T;
 
   const on: OnHandler<T> = (eventName, callback) => {
-    handlers[eventName].push(callback);
+    (handlers[eventName] as Array<typeof callback>).push(callback);
     return () => {
       removeFromArray(handlers[eventName], callback);
     };
   };
 
   const onChange: OnChangeHandler<T> = (propName, cb) => {
-    const setHandler = (key, newValue) => {
+    const setHandler = (key: keyof T, newValue: any) => {
       if (key === propName) {
         cb(newValue);
       }
@@ -121,7 +121,7 @@ export const createObservableMap = <T extends { [key: string]: any }>(
   };
 
   const use = (...subscriptions: Subscription<T>[]): (() => void) => {
-    const unsubs = subscriptions.reduce((unsubs, subscription) => {
+    const unsubs = subscriptions.reduce<(() => void)[]>((unsubs, subscription) => {
       if (subscription.set) {
         unsubs.push(on('set', subscription.set));
       }

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,7 +4,7 @@ import { ObservableMap } from './types';
 
 export const createStore = <T extends { [key: string]: any }>(
   defaultState?: T | (() => T),
-  shouldUpdate?: (newV: any, oldValue, prop: keyof T) => boolean,
+  shouldUpdate?: (newV: any, oldValue: any, prop: keyof T) => boolean,
 ): ObservableMap<T> => {
   const map = createObservableMap(defaultState, shouldUpdate);
   map.use(stencilSubscription());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": true,
+    "strict": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",
@@ -10,6 +11,7 @@
     ],
     "outDir": "build",
     "declarationDir": "dist",
+    "rootDir": "src",
     "moduleResolution": "bundler",
     "module": "esnext",
     "target": "es2022",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (no documentation changes needed)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

TypeScript 6 defaults `rootDir` to the directory containing `tsconfig.json`. As a result, the 2.2.3 build emits declarations under `dist/src/`, while the package's `types` and `exports.types` entries point to `dist/index.d.ts`. Consumers therefore cannot resolve the package declarations.

TypeScript 6 also enables strict mode by default, exposing existing implicit types during the build.

GitHub Issue Number: Closes #742

## What is the new behavior?

- Explicitly sets `rootDir` to `src`, restoring declarations such as `dist/index.d.ts` at the paths advertised by `package.json`.
- Explicitly enables strict mode and adds the minimal internal annotations needed for a clean TypeScript 6 build.
- Preserves the existing public API and runtime behavior.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npm test` (5 test files, 64 tests passed)
- `npm run prettier`
- `npm pack --dry-run --json` (verified `dist/index.d.ts`, `dist/index.js`, and `dist/index.cjs` are included)

## Other information

The declaration output regression was introduced by the TypeScript 6 default `rootDir` change. Setting `rootDir` explicitly makes the package layout independent of compiler defaults.
